### PR TITLE
Adds notice linking to ubuntu-core

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+> Notice: these images may not be fully up to date, it is suggested to use the [ubuntu-core](https://github.com/multiarch/ubuntu-core) image instead
+
 # :earth_africa: ubuntu-debootstrap [![Build Status](https://travis-ci.org/multiarch/ubuntu-debootstrap.svg?branch=master)](https://travis-ci.org/multiarch/ubuntu-debootstrap)
 
 ![](https://raw.githubusercontent.com/multiarch/dockerfile/master/logo.jpg)


### PR DESCRIPTION
Builds are failing on new images, my guess is due some missing support in the new versions. Probably better to focus on the ubuntu-core images instead