### PR TITLE
qemu 3.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
+dist: xenial
 sudo: required
 services: docker
 language: bash
 env:
     global:
-        - QEMU_VER=v2.12.0
+        - QEMU_VER=v3.1.0-3
         - DOCKER_REPO=multiarch/ubuntu-debootstrap
     matrix:
         - ARCH=amd64 INCLUDE=wget QEMU_ARCH=x86_64 SUITE=trusty UNAME_ARCH=x86_64 VERSION=14.04


### PR DESCRIPTION
While current used qemu-user-static version in the `ubuntu-bootstrap` container images is 2.12.0, the qemu version might cause a Java SIGSEGV issue ( https://github.com/multiarch/qemu-user-static/issues/18#issuecomment-477566296 ).

Could you upgrade the used qemu-user-static to the latest version 3.1.0?
I suppose `QEMU_VER` is used for 

https://github.com/multiarch/ubuntu-debootstrap/blob/master/update.sh#L62
```
wget -N https://github.com/multiarch/qemu-user-static/releases/download/${QEMU_VER}/x86_64_qemu-${QEMU_ARCH}-static.tar.gz
```

But if the qemu-user-static is used from github repository directly, why bionic's deb package `qemu-user-static` needs to be installed on below part?

https://github.com/multiarch/ubuntu-debootstrap/blob/master/.travis.yml#L33

```
$ sudo apt-get -yt bionic install qemu-user-static debootstrap
...
Get:1 http://archive.ubuntu.com/ubuntu bionic/universe amd64 qemu-user-static amd64 1:2.11+dfsg-1ubuntu7 [9,979 kB]
...
```
