### PR TITLE
Refactor .travis.yml and shell script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 dist: xenial
-sudo: required
 services: docker
 language: bash
 addons:
@@ -34,6 +33,10 @@ env:
         - ARCH=i386 INCLUDE=iproute2,wget QEMU_ARCH=i386 SUITE=bionic UNAME_ARCH=i386 VERSION=18.04
         - ARCH=ppc64el INCLUDE=iproute2,wget QEMU_ARCH=ppc64 SUITE=bionic UNAME_ARCH=ppc64el VERSION=18.04
 script:
-    - sudo ./update.sh -a "$ARCH" -v "$VERSION" -q "$QEMU_ARCH" -u "$QEMU_VER" -d "$DOCKER_REPO" -s "$SUITE" -i "$INCLUDE" -o "$UNAME_ARCH"
+    - ./update.sh -a "$ARCH" -v "$VERSION" -q "$QEMU_ARCH" -u "$QEMU_VER" -d "$DOCKER_REPO" -s "$SUITE" -i "$INCLUDE" -o "$UNAME_ARCH"
 after_success:
-    - if [[ $TRAVIS_PULL_REQUEST == 'false' ]]; then docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD" && docker push $DOCKER_REPO; fi
+    - |
+      if [[ $TRAVIS_BRANCH == 'master' && $TRAVIS_PULL_REQUEST == 'false' ]]; then
+          docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD" && \
+              docker push $DOCKER_REPO
+      fi

--- a/update.sh
+++ b/update.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/bin/bash
+set -eo pipefail
 
 # A POSIX variable
 OPTIND=1 # Reset in case getopts has been used previously in the shell.


### PR DESCRIPTION
I did refactoring. I wish these are useful for you.

### Remove unneeded sudo.

2 sudo commands in `update.sh` is good enough.

### Add "$TRAVIS_BRANCH == 'master'" condition to docker push to avoid wrongly executed at forked repository.

This is also for alignment with https://github.com/multiarch/qemu-user-static/blob/master/.travis.yml#L31-L34 .

### Add pipefail option.

Refer
https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo_pipefail/
https://stackoverflow.com/questions/32684119/exit-when-one-process-in-pipe-fails
This option is useful.

Because for example below lines in `update.sh`, when `sudo DEBOOTSTRAP="qemu-debootstrap" nice ionice -c 3 "$mkimage" "${args[@]}" 2>&1` returns error exit status, when the "pipefail" option is not set, the next command such as `sudo chown -R` is still executed. This situation is harmful.

```
sudo DEBOOTSTRAP="qemu-debootstrap" nice ionice -c 3 "$mkimage" "${args[@]}" 2>&1 | tee "$dir/build.log"
cat "$dir/build.log"
sudo chown -R "$(id -u):$(id -g)" "$dir"
```
